### PR TITLE
Fix existence check for `google` variable

### DIFF
--- a/wfes-reviewAddOrigLocation.js
+++ b/wfes-reviewAddOrigLocation.js
@@ -28,7 +28,7 @@
     if ((maxtries-- > 0)) {
       // only on location edits
       if (edit.what.location) {
-        if (undefined === typeof(google)) {
+        if ('undefined' === typeof(google)) {
           clearTimeout(timerId);
           timerId = setTimeout(addOrigMarker, 250);
           return;


### PR DESCRIPTION
`typeof` returns string value so the original check was never `true` leading to errors if `google` failed to load in time