### PR TITLE
Potential fix for code scanning alert no. 1789: Client-side cross-site scripting

### DIFF
--- a/wfes-AddTranslationButtons.js
+++ b/wfes-AddTranslationButtons.js
@@ -339,10 +339,18 @@
       })
       .catch((e) => {console.warn(GM_info.script.name, ": ", e);});
 
+    function escapeHTML(str) {
+      return str.replace(/[&<>"']/g, (char) => {
+        const escapeMap = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+        return escapeMap[char];
+      });
+    }
+
     function setDeepLText(text) {
       waitForElem(deeplInputArea)
         .then( elem => {
-          elem.innerHTML = `<p>${text.replace(/\n/g, "<br>")}</p>`;
+          const sanitizedText = escapeHTML(text).replace(/\n/g, "<br>");
+          elem.innerHTML = `<p>${sanitizedText}</p>`;
           // DeepL über Änderungen informieren
           elem.dispatchEvent(new InputEvent("input", { bubbles: true }));
         })

--- a/wfes-AddTranslationButtons.js
+++ b/wfes-AddTranslationButtons.js
@@ -1,5 +1,5 @@
 // @name         Add Translation Buttons
-// @version      2.3.0
+// @version      2.3.1
 // @description  Adds a button to translate the text associated with a wayspot
 // @author       AlterTobi
 // @match        https://wayfarer.nianticlabs.com/*


### PR DESCRIPTION
Potential fix for [https://github.com/AlterTobi/Wayfarer-Extension-Scripts/security/code-scanning/1789](https://github.com/AlterTobi/Wayfarer-Extension-Scripts/security/code-scanning/1789)

To fix the issue, we need to sanitize the `text` value before injecting it into the DOM. This can be achieved by escaping special HTML characters (`<`, `>`, `&`, `"`, `'`) to prevent malicious scripts from being executed. A utility function for escaping HTML should be introduced and applied to the `text` value before constructing the HTML string.

**Steps to fix:**
1. Define a utility function `escapeHTML` to escape special HTML characters.
2. Use this function to sanitize the `text` value in the `setDeepLText` function before injecting it into the DOM.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
